### PR TITLE
Smaller core JSON

### DIFF
--- a/src/Language/PureScript/CoreFn/ToJSON.hs
+++ b/src/Language/PureScript/CoreFn/ToJSON.hs
@@ -53,7 +53,9 @@ recordToJSON :: (a -> Value) -> [(String, a)] -> Value
 recordToJSON f = object . map (\(label, a) -> pack label .= f a)
 
 exprToJSON :: Expr a -> Value
-exprToJSON (Var _ i)              = qualifiedToJSON runIdent i
+exprToJSON (Var _ i)              = toJSON ( "Var"
+                                           , qualifiedToJSON runIdent i
+                                           )
 exprToJSON (Literal _ l)          = toJSON ( "Literal"
                                            , literalToJSON (exprToJSON) l
                                            )
@@ -96,7 +98,9 @@ caseAlternativeToJSON (CaseAlternative bs r') =
          ]
 
 binderToJSON :: Binder a -> Value
-binderToJSON (VarBinder _ v)              = identToJSON v
+binderToJSON (VarBinder _ v)              = toJSON ( "VarBinder"
+                                                   , identToJSON v
+                                                   )
 binderToJSON (NullBinder _)               = toJSON "NullBinder"
 binderToJSON (LiteralBinder _ l)          = toJSON ( "LiteralBinder"
                                                    , literalToJSON binderToJSON l

--- a/src/Language/PureScript/CoreFn/ToJSON.hs
+++ b/src/Language/PureScript/CoreFn/ToJSON.hs
@@ -4,7 +4,6 @@
 --
 module Language.PureScript.CoreFn.ToJSON
   ( moduleToJSON
-  , annToJSON
   ) where
 
 import Prelude.Compat
@@ -13,177 +12,102 @@ import Data.Aeson
 import Data.Text (pack)
 
 import Language.PureScript.AST.Literals
-import Language.PureScript.Comments
 import Language.PureScript.CoreFn
 import Language.PureScript.Names
-import Language.PureScript.Types
 
 literalToJSON :: (a -> Value) -> Literal a -> Value
-literalToJSON _ (NumericLiteral (Left n)) = toJSON ("NumericLiteral", "Int", n)
-literalToJSON _ (NumericLiteral (Right n)) = toJSON ("NumericLiteral", "Number", n)
+literalToJSON _ (NumericLiteral (Left n)) = toJSON ("IntLiteral", n)
+literalToJSON _ (NumericLiteral (Right n)) = toJSON ("NumberLiteral", n)
 literalToJSON _ (StringLiteral s) = toJSON ("StringLiteral", s)
 literalToJSON _ (CharLiteral c) = toJSON ("CharLiteral", c)
 literalToJSON _ (BooleanLiteral b) = toJSON ("BooleanLiteral", b)
 literalToJSON t (ArrayLiteral xs) = toJSON ("ArrayLiteral", map t xs)
-literalToJSON t (ObjectLiteral xs) = toJSON ("ObjectLiteral", map (fmap t) xs)
-
-annToJSON :: Ann -> Value
-annToJSON (_ss, cs, _t, m) = toJSON ( Null -- sourceSpanToJSON <$> ss
-                                    , map commentToJSON cs
-                                    , Null -- typeToJSON <$> t
-                                    , metaToJSON <$> m
-                                    )
-
-metaToJSON :: Meta -> Value
-metaToJSON (IsConstructor t is) = toJSON ("IsConstructor", constructorTypeToJSON t, map identToJSON is)
-metaToJSON IsNewtype = toJSON ["IsNewtype"]
-metaToJSON IsTypeClassConstructor = toJSON ["IsTypeClassConstructor"]
-metaToJSON IsForeign = toJSON ["IsForeign"]
-
-constructorTypeToJSON :: ConstructorType -> Value
-constructorTypeToJSON ProductType = toJSON ["ProductType"]
-constructorTypeToJSON SumType = toJSON ["SumType"]
-
-{-
-sourceSpanToJSON :: SourceSpan -> Value
-sourceSpanToJSON (SourceSpan name start end) =
-  object [ pack "spanName" .= name
-         , pack "spanStart" .= sourcePosToJSON start
-         , pack "spanEnd" .= sourcePosToJSON end
-         ]
-
-sourcePosToJSON :: SourcePos -> Value
-sourcePosToJSON (SourcePos line col) =
-  object [ pack "sourcePosLine" .= line
-         , pack "sourcePosColumn" .= col
-         ]
--}
+literalToJSON t (ObjectLiteral xs) = toJSON ("ObjectLiteral", recordToJSON t xs)
 
 identToJSON :: Ident -> Value
-identToJSON (Ident s) = toJSON ("Ident", s)
-identToJSON (GenIdent s i) = toJSON ("GenIdent", s, i)
+identToJSON = toJSON . runIdent
 
 qualifiedToJSON :: (a -> Value) -> Qualified a -> Value
-qualifiedToJSON t (Qualified m i) =
-  toJSON (fmap moduleNameToJSON m, t i)
+qualifiedToJSON t (Qualified Nothing i) = t i
+qualifiedToJSON t (Qualified (Just mn) i) = toJSON [moduleNameToJSON mn, t i]
 
 moduleNameToJSON :: ModuleName -> Value
-moduleNameToJSON (ModuleName ss) = toJSON (map properNameToJSON ss)
+moduleNameToJSON = toJSON . runModuleName
 
 properNameToJSON :: ProperName a -> Value
 properNameToJSON (ProperName n) = toJSON n
 
-commentToJSON :: Comment -> Value
-commentToJSON (LineComment s) = toJSON ("LineComment", s)
-commentToJSON (BlockComment s) = toJSON ("BlockComment", s)
+moduleToJSON :: Module a -> Value
+moduleToJSON m = object [ pack "imports"  .= map (moduleNameToJSON . snd) (moduleImports m)
+                        , pack "exports"  .= map identToJSON (moduleExports m)
+                        , pack "foreign"  .= map (identToJSON . fst) (moduleForeign m)
+                        , pack "decls"    .= recordToJSON exprToJSON (foldMap fromBind (moduleDecls m))
+                        ]
 
-moduleToJSON :: (a -> Value) -> Module a -> Value
-moduleToJSON t m = toJSON ( "Module"
-                          , object [ pack "moduleComments" .= map commentToJSON (moduleComments m)
-                                   , pack "moduleName" .= moduleNameToJSON (moduleName m)
-                                   , pack "moduleImports" .= map (moduleImportToJSON t) (moduleImports m)
-                                   , pack "moduleExports" .= map identToJSON (moduleExports m)
-                                   , pack "moduleForeign" .= map foreignDeclToJSON (moduleForeign m)
-                                   , pack "moduleDecls" .= map (bindToJSON t) (moduleDecls m)
-                                   ]
-                          )
+fromBind :: Bind a -> [(String, Expr a)]
+fromBind (NonRec _ n e) = [(runIdent n, e)]
+fromBind (Rec bs) = map (\((_, n), e) -> (runIdent n, e)) bs
 
-moduleImportToJSON :: (a -> Value) -> (a, ModuleName) -> Value
-moduleImportToJSON t (a, n) = toJSON (t a, moduleNameToJSON n)
+recordToJSON :: (a -> Value) -> [(String, a)] -> Value
+recordToJSON f = object . map (\(label, a) -> pack label .= f a)
 
-foreignDeclToJSON :: ForeignDecl -> Value
-foreignDeclToJSON (i, t) = toJSON (identToJSON i, typeToJSON t)
+exprToJSON :: Expr a -> Value
+exprToJSON (Var _ i)              = qualifiedToJSON identToJSON i
+exprToJSON (Literal _ l)          = toJSON ( "Literal"
+                                           , literalToJSON (exprToJSON) l
+                                           )
+exprToJSON (Constructor _ d c is) = toJSON ( "Constructor"
+                                           , properNameToJSON d
+                                           , properNameToJSON c
+                                           , map identToJSON is
+                                           )
+exprToJSON (Accessor _ f r)       = toJSON ( "Accessor"
+                                           , f
+                                           , exprToJSON r
+                                           )
+exprToJSON (ObjectUpdate _ r fs)  = toJSON ( "ObjectUpdate"
+                                           , exprToJSON r
+                                           , recordToJSON exprToJSON fs
+                                           )
+exprToJSON (Abs _ p b)            = toJSON ( "Abs"
+                                           , identToJSON p
+                                           , exprToJSON b
+                                           )
+exprToJSON (App _ f x)            = toJSON ( "App"
+                                           , exprToJSON f
+                                           , exprToJSON x
+                                           )
+exprToJSON (Case _ ss cs)         = toJSON ( "Case"
+                                           , map exprToJSON ss
+                                           , map caseAlternativeToJSON cs
+                                           )
+exprToJSON (Let _ bs e)           = toJSON ( "Let"
+                                           , recordToJSON exprToJSON (foldMap fromBind bs)
+                                           , exprToJSON e
+                                           )
 
-typeToJSON :: Type -> Value
-typeToJSON = const Null
-{-
-typeToJSON (TUnknown n) = toJSON ("TUnknown", n)
-typeToJSON (TypeVar v) = toJSON ("TypeVar", v)
-typeToJSON (TypeLevelString s) = toJSON ("TypeLevelString", s)
-typeToJSON (TypeWildcard s) = toJSON ("TypeWildcard", sourceSpanToJSON s)
-typeToJSON (TypeConstructor q) = toJSON ("TypeConstructor", qualifiedToJSON properNameToJSON q)
-typeToJSON (TypeOp n) = toJSON ("TypeOp", qualifiedToJSON opNameToJSON n)
-typeToJSON (TypeApp f x) = toJSON ("TypeApp", typeToJSON f, typeToJSON x)
-typeToJSON (ForAll s t ss) = toJSON ("ForAll", s, typeToJSON t, skolemScopeToJSON <$> ss)
-typeToJSON (ConstrainedType cs t) = toJSON ("ConstrainedType", map constraintToJSON cs, typeToJSON t)
-typeToJSON (Skolem s i sc ss) = toJSON ("Skolem", s, i, skolemScopeToJSON sc, sourceSpanToJSON <$> ss)
-typeToJSON REmpty = toJSON ["REmpty"]
-typeToJSON (RCons s t tl) = toJSON ("RCons", s, typeToJSON t, typeToJSON tl)
-typeToJSON (KindedType t k) = toJSON ("KindedType", typeToJSON t, kindToJSON k)
-typeToJSON PrettyPrintFunction{} = internalError "CoreFn.ToJSON: PrettyPrintFunction was not erased"
-typeToJSON PrettyPrintObject{} = internalError "CoreFn.ToJSON: PrettyPrintObject was not erased"
-typeToJSON PrettyPrintForAll{} = internalError "CoreFn.ToJSON: PrettyPrintForAll was not erased"
-typeToJSON BinaryNoParensType{} = internalError "CoreFn.ToJSON: BinaryNoParensType was not erased"
-typeToJSON ParensInType{} = internalError "CoreFn.ToJSON: ParensInType was not erased"
-
-kindToJSON :: Kind -> Value
-kindToJSON (KUnknown n) = toJSON ("KUnknown", n)
-kindToJSON Star = toJSON ["Star"]
-kindToJSON Bang = toJSON ["Bang"]
-kindToJSON (Row boat) = toJSON ("Row", kindToJSON boat)
-kindToJSON (FunKind d c) = toJSON ("FunKind", kindToJSON d, kindToJSON c)
-kindToJSON Symbol = toJSON ["Symbol"]
-
-opNameToJSON :: OpName a -> Value
-opNameToJSON (OpName s) = toJSON ("OpName", s)
-
-constraintToJSON :: Constraint -> Value
-constraintToJSON (Constraint cls args dat) =
-  object [ pack "constraintClass" .= qualifiedToJSON properNameToJSON cls
-         , pack "constraintArgs" .= map typeToJSON args
-         , pack "constraintData" .= (constraintDataToJSON <$> dat)
+caseAlternativeToJSON :: CaseAlternative a -> Value
+caseAlternativeToJSON (CaseAlternative bs r') =
+  toJSON [ toJSON (map binderToJSON bs)
+         , case r' of
+             Left rs -> toJSON $ map (\(g, e) -> (exprToJSON g, exprToJSON e)) rs
+             Right r -> exprToJSON r
          ]
 
-constraintDataToJSON :: ConstraintData -> Value
-constraintDataToJSON (PartialConstraintData cs b) =
-  toJSON ("PartialConstraintData", cs, b)
-
-skolemScopeToJSON :: SkolemScope -> Value
-skolemScopeToJSON (SkolemScope n) = toJSON ("SkolemScope", n)
--}
-
-bindToJSON :: (a -> Value) -> Bind a -> Value
-bindToJSON t (NonRec a n e) = toJSON ("NonRec", t a, identToJSON n, exprToJSON t e)
-bindToJSON t (Rec bs) = toJSON ("Rec", map go bs)
-  where go ((a, n), e) = toJSON ((t a, identToJSON n), exprToJSON t e)
-
-exprToJSON :: (a -> Value) -> Expr a -> Value
-exprToJSON t (Literal a l) = toJSON ("Literal", t a, literalToJSON (exprToJSON t) l)
-exprToJSON t (Constructor a d c is) =
-  toJSON ("Constructor", t a, properNameToJSON d, properNameToJSON c, map identToJSON is)
-exprToJSON t (Accessor a f r) = toJSON ("Accessor", t a, f, exprToJSON t r)
-exprToJSON t (ObjectUpdate a r fs) =
-  toJSON ("ObjectUpdate", t a, exprToJSON t r, map (fmap (exprToJSON t)) fs)
-exprToJSON t (Abs a p b) = toJSON ("Abs", t a, identToJSON p, exprToJSON t b)
-exprToJSON t (App a f x) = toJSON ("App", t a, exprToJSON t f, exprToJSON t x)
-exprToJSON t (Var a i) = toJSON ("Var", t a, qualifiedToJSON identToJSON i)
-exprToJSON t (Case a ss cs) =
-  toJSON ("Case", t a, map (exprToJSON t) ss, map (caseAlternativeToJSON t) cs)
-exprToJSON t (Let a bs e) = toJSON ("Let", t a, map (bindToJSON t) bs, exprToJSON t e)
-
-caseAlternativeToJSON :: (a -> Value) -> CaseAlternative a -> Value
-caseAlternativeToJSON t (CaseAlternative bs r') =
-  object [ pack "caseAlternativeBinders" .= map (binderToJSON t) bs
-         , pack "caseAlternativeResult" .=
-             case r' of
-               Left rs -> toJSON ( "Left"
-                                 , map (\(g, e) -> (exprToJSON t g, exprToJSON t e))
-                                       rs
-                                 )
-               Right r -> toJSON ("Right", exprToJSON t r)
-         ]
-
-binderToJSON :: (a -> Value) -> Binder a -> Value
-binderToJSON t (NullBinder a) = toJSON ("NullBinder", t a)
-binderToJSON t (LiteralBinder a l) =
-  toJSON ("LiteralBinder", t a, literalToJSON (binderToJSON t) l)
-binderToJSON t (VarBinder a v) = toJSON ("VarBinder", t a, identToJSON v)
-binderToJSON t (ConstructorBinder a d c bs) =
-  toJSON ( "ConstructorBinder"
-         , t a
-         , qualifiedToJSON properNameToJSON d
-         , qualifiedToJSON properNameToJSON c
-         , map (binderToJSON t) bs
-         )
-binderToJSON t (NamedBinder a n b) =
-  toJSON ("NamedBinder", t a, identToJSON n, binderToJSON t b)
+binderToJSON :: Binder a -> Value
+binderToJSON (NullBinder _)               = toJSON "NullBinder"
+binderToJSON (LiteralBinder _ l)          = toJSON ( "LiteralBinder"
+                                                   , literalToJSON binderToJSON l
+                                                   )
+binderToJSON (VarBinder _ v)              = toJSON ( "VarBinder"
+                                                   , identToJSON v
+                                                   )
+binderToJSON (ConstructorBinder _ d c bs) = toJSON ( "ConstructorBinder"
+                                                   , qualifiedToJSON properNameToJSON d
+                                                   , qualifiedToJSON properNameToJSON c
+                                                   , map binderToJSON bs
+                                                   )
+binderToJSON (NamedBinder _ n b)          = toJSON ( "NamedBinder"
+                                                   , identToJSON n
+                                                   , binderToJSON b
+                                                   )

--- a/src/Language/PureScript/Make.hs
+++ b/src/Language/PureScript/Make.hs
@@ -375,10 +375,8 @@ buildMakeActions outputDir filePathMap foreigns usePrefix =
     dumpCoreFn <- lift $ asks optionsDumpCoreFn
     when dumpCoreFn $ do
       let coreFnFile = outputDir </> filePath </> "corefn.json"
-      let jsonPayload = CFJ.moduleToJSON m
-      let json = Aeson.object [ ("version", Aeson.toJSON $ showVersion Paths.version)
-                              , (fromString (runModuleName mn), jsonPayload)
-                              ]
+      let jsonPayload = CFJ.moduleToJSON Paths.version m
+      let json = Aeson.object [ (fromString (runModuleName mn), jsonPayload) ]
       lift $ writeTextFile coreFnFile (BU8.toString . B.toStrict . encode $ json)
 
   genSourceMap :: String -> String -> Int -> [SMap] -> Make ()

--- a/src/Language/PureScript/Make.hs
+++ b/src/Language/PureScript/Make.hs
@@ -375,9 +375,9 @@ buildMakeActions outputDir filePathMap foreigns usePrefix =
     dumpCoreFn <- lift $ asks optionsDumpCoreFn
     when dumpCoreFn $ do
       let coreFnFile = outputDir </> filePath </> "corefn.json"
-      let jsonPayload = CFJ.moduleToJSON CFJ.annToJSON m
+      let jsonPayload = CFJ.moduleToJSON m
       let json = Aeson.object [ ("version", Aeson.toJSON $ showVersion Paths.version)
-                              , ("payload", jsonPayload)
+                              , (fromString (runModuleName mn), jsonPayload)
                               ]
       lift $ writeTextFile coreFnFile (BU8.toString . B.toStrict . encode $ json)
 


### PR DESCRIPTION
This reduces the generated core JSON to the bare minimum for a first version. Compare here:

https://gist.github.com/paf31/3085271ba4aebe6f3bf02ca5d9596bf8

In fact, the JSON is smaller than the JavaScript in many cases. Thermite compiles to 18K of JSON compared to 19K of compiled JS.

Also, the sexpr-like encoding is quite readable too.